### PR TITLE
Prevent RGBA error

### DIFF
--- a/mmaker_color_enhance_core.py
+++ b/mmaker_color_enhance_core.py
@@ -6,6 +6,11 @@ import imageio.core.util
 imageio.core.util._precision_warn = lambda *args, **kwargs: None
 
 def color_enhance(arr, strength: float = 1) -> Image.Image:
+    if arr.mode == 'RGBA':
+        arr = arr.convert('RGB')
+
+    arr_np = np.array(arr)
+
     lch = skimage.color.lab2lch(lab=skimage.color.rgb2lab(rgb=np.array(arr, dtype=np.uint8)))
     lch[:, :, 1] *= 100/(lerp(100, lch[:, :, 1].max(), strength)) # Normalize chroma component
     return Image.fromarray(np.array(skimage.color.lab2rgb(lab=skimage.color.lch2lab(lch=lch)) * 255, dtype=np.uint8))


### PR DESCRIPTION
This PR prevents RGBA errors like this: `ValueError: the input array must have size 3 along channel_axis, got (1360, 1024, 4)`